### PR TITLE
Specify project schema in the backend

### DIFF
--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Admin.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Admin.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "admin_table")
+@Table(name = "admin_table", schema = "project")
 @PrimaryKeyJoinColumn(name = "id_user")
 public class Admin extends User {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Adopter.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Adopter.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 
 @Data
 @Entity
-@Table(name = "adopter")
+@Table(name = "adopter", schema = "project")
 @RequiredArgsConstructor
 @PrimaryKeyJoinColumn(name = "id_user")
 public class Adopter extends User {

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Adoption.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Adoption.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "adoption")
+@Table(name = "adoption", schema = "project")
 public class Adoption {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Category.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Category.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "category")
+@Table(name = "category", schema = "project")
 public class Category {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Donor.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Donor.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "donor")
+@Table(name = "donor", schema = "project")
 @PrimaryKeyJoinColumn(name = "id_user")
 public class Donor extends User {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Employee.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Employee.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "employee")
+@Table(name = "employee", schema = "project")
 @PrimaryKeyJoinColumn(name = "id_user")
 public class Employee extends User {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Food.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Food.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "food")
+@Table(name = "food", schema = "project")
 public class Food {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Organisation.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Organisation.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "organisation")
+@Table(name = "organisation", schema = "project")
 public class Organisation {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/PersonalProfile.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/PersonalProfile.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "personal_profile")
+@Table(name = "personal_profile", schema = "project")
 public class PersonalProfile {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Pet.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Pet.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "pet")
+@Table(name = "pet", schema = "project")
 public class Pet {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Post.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Post.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "post")
+@Table(name = "post", schema = "project")
 public class Post {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Shelter.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Shelter.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "shelter")
+@Table(name = "shelter", schema = "project")
 public class Shelter {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Surendee.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Surendee.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "surendee")
+@Table(name = "surendee", schema = "project")
 @PrimaryKeyJoinColumn(name = "id_user")
 public class Surendee extends User {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Therapy.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/Therapy.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "therapy")
+@Table(name = "therapy", schema = "project")
 public class Therapy {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/User.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/User.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "user_table")
+@Table(name = "user_table", schema = "project")
 @Inheritance(strategy = InheritanceType.JOINED)
 public class User {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/VetClinic.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/entities/VetClinic.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "vet_clinic")
+@Table(name = "vet_clinic", schema = "project")
 public class VetClinic {
 
     @Id

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/DonorDonatesToOrganisation.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/DonorDonatesToOrganisation.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "donor_donates_to_organisation")
+@Table(name = "donor_donates_to_organisation", schema = "project")
 @IdClass(DonorDonatesToOrganisationId.class)
 public class DonorDonatesToOrganisation {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetBelongsToCategory.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetBelongsToCategory.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "pet_belongs_to_category")
+@Table(name = "pet_belongs_to_category", schema = "project")
 @IdClass(PetBelongsToCategoryId.class)
 public class PetBelongsToCategory {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetNeedsInterventionInVetClinic.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetNeedsInterventionInVetClinic.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "pet_needs_intervention_in_vet_clinic")
+@Table(name = "pet_needs_intervention_in_vet_clinic", schema = "project")
 @IdClass(PetNeedsInterventionInVetClinicId.class)
 public class PetNeedsInterventionInVetClinic {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetNeedsTherapy.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetNeedsTherapy.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "pet_needs_therapy")
+@Table(name = "pet_needs_therapy", schema = "project")
 @IdClass(PetNeedsTherapyId.class)
 public class PetNeedsTherapy {
 

--- a/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetPreferablyEatsFood.java
+++ b/Prototype Application/Paw5/src/main/java/finki/paw5/model/relations/PetPreferablyEatsFood.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @Entity
 @RequiredArgsConstructor
-@Table(name = "pet_preferably_eats_food")
+@Table(name = "pet_preferably_eats_food", schema = "project")
 @IdClass(PetPreferablyEatsFoodId.class)
 public class PetPreferablyEatsFood {
 


### PR DESCRIPTION
The default schema used is the public schema, but since it's required to use the project schema for grading I changed the backend to also use that same schema.

Changes made for all entities and relations i.e. the schema is specified for all classes connected to tables in the database.